### PR TITLE
Adds CrashLoopBackOff check

### DIFF
--- a/internal/checks/check.go
+++ b/internal/checks/check.go
@@ -10,6 +10,7 @@ func IssueList(clientset kubernetes.Interface) ([]Issue, error) {
 
 	funcs := []func(clientset kubernetes.Interface) ([]Issue, error){
 		AutoscalerStatus,
+		PodCrashLoopBackOff,
 		NodeStatus,
 	}
 

--- a/internal/checks/const.go
+++ b/internal/checks/const.go
@@ -1,0 +1,12 @@
+package checks
+
+const (
+	// LevelCritical is used to determine which components are critical to a clusters operations.
+	LevelCritical = "critical"
+
+	// ReasonCrashLoopBackOff is used for determining if a Pod has been restarted too many times.
+	ReasonCrashLoopBackOff = "CrashLoopBackOff"
+
+	// LabelClusterHealthz is used when querying for resources which need to be checked.
+	LabelClusterHealthz = "skpr.io/cluster-healthz"
+)

--- a/internal/checks/pod_crashloop.go
+++ b/internal/checks/pod_crashloop.go
@@ -1,0 +1,44 @@
+package checks
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// PodCrashLoopBackOff reviews the status of all Pod marked with a label to detmine if they are in a CrashLoopBackOff.
+func PodCrashLoopBackOff(clientset kubernetes.Interface) ([]Issue, error) {
+	var issues []Issue
+
+	list, err := clientset.CoreV1().Pods(corev1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(map[string]string{
+			LabelClusterHealthz: LevelCritical,
+		}),
+	})
+	if err != nil {
+		return issues, err
+	}
+
+	for _, pod := range list.Items {
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.State.Waiting == nil {
+				continue
+			}
+
+			if container.State.Waiting.Reason == ReasonCrashLoopBackOff {
+				issues = append(issues, Issue{
+					Name:        fmt.Sprintf("%s~%s", pod.ObjectMeta.Name, container.Name),
+					Issue:       ReasonCrashLoopBackOff,
+					// @todo, Make this more specific eg. OOM
+					Description: "The Pod has restarted too many times.",
+					Command:     fmt.Sprintf("kubectl -n %s describe pod %s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name),
+				})
+			}
+		}
+	}
+
+	return issues, nil
+}

--- a/internal/checks/pod_crashloop_test.go
+++ b/internal/checks/pod_crashloop_test.go
@@ -1,0 +1,67 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPodCrashLoopBackOff(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fail",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					LabelClusterHealthz: LevelCritical,
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "container1",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: ReasonCrashLoopBackOff,
+
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pass",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					LabelClusterHealthz: LevelCritical,
+				},
+			},
+		},
+	}
+
+	for _, pod := range pods {
+		_, err := clientset.CoreV1().Pods(pod.ObjectMeta.Namespace).Create(&pod)
+		assert.Nil(t, err)
+	}
+
+	issues, err := PodCrashLoopBackOff(clientset)
+	assert.Nil(t, err)
+
+	expected := []Issue{
+		{
+			Name:        "fail~container1",
+			Issue:       ReasonCrashLoopBackOff,
+			Description: "The Pod has restarted too many times.",
+			Command:     "kubectl -n kube-system describe pod fail",
+		},
+	}
+
+	assert.Equal(t, expected, issues)
+}


### PR DESCRIPTION
* Adds a check to ensure that Pods are not in a state of `CrashLoopBackOff`
* Requires Pods to be labels with `skpr.io/cluster-healthz=critical`